### PR TITLE
added acess to /media

### DIFF
--- a/com.github.mtkennerly.ludusavi.yaml
+++ b/com.github.mtkennerly.ludusavi.yaml
@@ -15,6 +15,7 @@ finish-args:
   ## Needed for custom paths and restoring saves
   - --filesystem=home
   - --filesystem=/run/media/
+  - --filesystem=/media/
   ## GPU acceration
   - --device=dri
   ## Fix for GUI being to large on the steam deck


### PR DESCRIPTION
Some Distros mount drives to /media/ instead of run, media so this allows access to drives on these distrobutions.