### PR TITLE
Add permission for other apps' data to make custom backups easier

### DIFF
--- a/com.github.mtkennerly.ludusavi.yaml
+++ b/com.github.mtkennerly.ludusavi.yaml
@@ -17,12 +17,13 @@ finish-args:
   - --filesystem=home
   - --filesystem=/run/media/
   - --filesystem=/media/
-  ### Necessary for Steam flatpak
+  ### Necessary for built-in integration with other apps
   - --filesystem=~/.var/app/com.valvesoftware.Steam
-  ### Necessary for Heroic flatpak
   - --filesystem=~/.var/app/com.heroicgameslauncher.hgl
-  ### Necessary for Lutris flatpak
   - --filesystem=~/.var/app/net.lutris.Lutris
+  ### Aside from those apps that Ludusavi automatically supports,
+  ### users commonly want to back up data from other apps as well.
+  - --filesystem=~/.var/app/
   ## GPU acceleration
   - --device=dri
   ## Fix for GUI being too large on the steam deck


### PR DESCRIPTION
This most recently came up in https://github.com/mtkennerly/ludusavi/issues/303 , but it has come up before as well. Users may want to back up data from other apps (particularly emulators, but some games are also available via Flatpak), and it can be confusing when Ludusavi fails to find the data. Ludusavi can also dynamically detect saves for any [manifest entry](https://github.com/mtkennerly/ludusavi-manifest) that sets the `id.flatpak` field, so it would be nice if that functionality worked by default.

For precedent, I found [some other apps](https://github.com/search?q=org%3Aflathub+filesystem%3D%7E%2F.var%2Fapp&type=code) that have this blanket permission, which tend to be backup or file comparison apps (e.g., Vorta, KopiaUI, FreeFileSync, Czkawka).