### PR TITLE
Bumped rclone to 1.73.2

### DIFF
--- a/com.github.mtkennerly.ludusavi.yaml
+++ b/com.github.mtkennerly.ludusavi.yaml
@@ -66,10 +66,11 @@ modules:
       - type: archive
         only-arches:
           - x86_64
-        url: https://github.com/rclone/rclone/releases/download/v1.69.1/rclone-v1.69.1-linux-amd64.zip
-        sha256: 231841f8d8029ae6cfca932b601b3b50d0e2c3c2cb9da3166293f1c3eae7d79c
+        url: https://github.com/rclone/rclone/releases/download/v1.73.2/rclone-v1.73.2-linux-amd64.zip
+        sha256: 00a1d8cb85552b7b07bb0416559b2e78fcf9c6926662a52682d81b5f20c90535
       - type: archive
         only-arches:
           - aarch64
-        url: https://github.com/rclone/rclone/releases/download/v1.69.1/rclone-v1.69.1-linux-arm64.zip
-        sha256: a03de8f700fcda7a1aef6b568f88d44218b698fb4e1637596c024d341bb24124
+        url: https://github.com/rclone/rclone/releases/download/v1.73.2/rclone-v1.73.2-linux-arm64.zip
+        sha256: 2f7d8b807e6ea638855129052c834ca23aa538d3ad7786e30b8ad1e97c5db47b
+


### PR DESCRIPTION
Hello!

This is mostly due to rclone having added support for MEGA's 2fa in 1.72.0 (2025-11-21), which is quite handy (although it'll need manual setup via `flatpak run --command=rclone com.github.mtkennerly.ludusavi config`).

I've read through the [changelog](https://rclone.org/changelog/#v1-73-2-2026-03-06) and there doesn't seem to have been any breaking changes since 1.69.1, so I added in the latest version available.